### PR TITLE
Feature/multi graph connections

### DIFF
--- a/Web.NetCore/GraphExplorer/ClientApp/app/components/network/network.html
+++ b/Web.NetCore/GraphExplorer/ClientApp/app/components/network/network.html
@@ -27,6 +27,11 @@
             <button class="blackBtn" type="submit" disabled.bind="!query || loading">Execute</button>
         </fieldset>
         <fieldset class="selectWrapper floatRight">
+            <select value.bind="selectedConnection" change.delegate="connectionChange()" id="connectionCombo">
+                <option repeat.for="con of connections" model.bind="con">${con}</option>
+            </select>
+        </fieldset>
+        <fieldset class="selectWrapper floatRight">
             <select value.bind="selectedCollection" change.delegate="collectionChange()" id="collectionCombo">
                 <option repeat.for="col of collections" model.bind="col">${col}</option>
             </select>

--- a/Web.NetCore/GraphExplorer/Configuration/DocDbConfig.cs
+++ b/Web.NetCore/GraphExplorer/Configuration/DocDbConfig.cs
@@ -1,10 +1,32 @@
-﻿namespace GraphExplorer.Configuration
+﻿using Microsoft.Azure.Documents.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GraphExplorer.Configuration
 {
-	/// <summary>
-	/// Represents a collection of configuration settings for DocDb connection
-	/// </summary>
-	public class DocDbConfig
-	{
+    public class DocDbConfigSettings
+    {
+        private DocDbConfig[] _array;
+
+        public DocDbConfig[] Array
+        {
+            get { return _array; }
+            set
+            {
+                _array = value;
+                Config = Array.ToDictionary(k => k.Database, v => new DocumentClient(new Uri(v.Endpoint), v.AuthKey, new ConnectionPolicy { EnableEndpointDiscovery = false }));
+            }
+        }
+
+        public Dictionary<string, DocumentClient> Config;
+    }
+
+    /// <summary>
+    /// Represents a configuration setting for DocDb connection
+    /// </summary>
+    public class DocDbConfig
+    {
         public string Endpoint { get; set; }
         public string AuthKey { get; set; }
         public string Database { get; set; }

--- a/Web.NetCore/GraphExplorer/Startup.cs
+++ b/Web.NetCore/GraphExplorer/Startup.cs
@@ -34,7 +34,7 @@ namespace GraphExplorer
 
             services.AddOptions();
 
-            services.Configure<DocDbConfig>(Configuration.GetSection("DocumentDBConfig"));
+            services.Configure<DocDbConfigSettings>(Configuration.GetSection("DocumentDBConfig"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Web.NetCore/GraphExplorer/appsettings.json
+++ b/Web.NetCore/GraphExplorer/appsettings.json
@@ -1,9 +1,12 @@
 {
-  "DocumentDBConfig":
-  {
-    "endpoint": "DOCUMENTDBURL",
-    "authKey": "DOCUMENTDBSECRET",
-    "database": "DOCUMENTDBDATABASEID"
+  "DocumentDBConfig": {
+    "Array": [
+      {
+        "endpoint": "DOCUMENTDBURL",
+        "authKey": "DOCUMENTDBSECRET",
+        "database": "DOCUMENTDBDATABASEID"
+      }
+    ]
   },
   "Logging": 
   {

--- a/Web/GraphExplorer/ClientApp/app/components/network/network.html
+++ b/Web/GraphExplorer/ClientApp/app/components/network/network.html
@@ -27,6 +27,11 @@
             <button class="blackBtn" type="submit" disabled.bind="!query || loading">Execute</button>
         </fieldset>
         <fieldset class="selectWrapper floatRight">
+            <select value.bind="selectedConnection" change.delegate="connectionChange()" id="connectionCombo">
+                <option repeat.for="con of connections" model.bind="con">${con}</option>
+            </select>
+        </fieldset>
+        <fieldset class="selectWrapper floatRight">
             <select value.bind="selectedCollection" change.delegate="collectionChange()" id="collectionCombo">
                 <option repeat.for="col of collections" model.bind="col">${col}</option>
             </select>

--- a/Web/GraphExplorer/ClientApp/app/components/network/network.ts
+++ b/Web/GraphExplorer/ClientApp/app/components/network/network.ts
@@ -98,8 +98,10 @@ export class Network
     edgeSize = "1";
     iconSize = "25";
 
+    connections: Array<string>;
     collections: Array<string>;
     selectedCollection: string;
+    selectedConnection: string;
     collectionTitle: string;
 
     labelMappings: { [label: string]: string } = {};
@@ -112,7 +114,7 @@ export class Network
     constructor(http: HttpClient, eventAggregator: EventAggregator)
     {
         this.http = http;
-        this.getCollections();
+        this.getConnections();
 
         eventAggregator.subscribe('consoleupdate', response =>
         {
@@ -130,7 +132,7 @@ export class Network
 
         this.progressText = "Querying DocumentDB";
         this.loading = true;
-        this.http.fetch(`api/gremlin?query=${this.query}&collectionId=${this.selectedCollection}`)
+        this.http.fetch(`api/gremlin?query=${this.query}&collectionId=${this.selectedCollection}&connectionName=${this.selectedConnection}`)
             .then((response: any) => { return this.handleErrors(response); })
             .then(result => result.json())
             .then((data: any) =>
@@ -298,6 +300,11 @@ export class Network
         this.theConsole.clear();
         this.getSavedQueries();
         this.getSavedSettings();
+    }
+
+    connectionChange() {
+        this.collectionTitle = '';
+        this.getCollections();
     }
 
     private setNodeOrEdgeSize(type, value)
@@ -571,10 +578,23 @@ export class Network
         }, 500);
     }
 
+    private getConnections() {
+        this.http.fetch('api/collection/connections')
+            .then((response: any) => { return this.handleErrors(response); })
+            .then(result => result.json())
+            .then((data: any) => {
+                this.connections = data;
+                if (this.connections && this.connections.length > 0) {
+                    this.selectedConnection = this.connections[0];
+                    this.getCollections();
+                }
+            })
+    }
+
     /* manipulating collection methods */
     private getCollections()
     {
-        this.http.fetch('api/collection')
+        this.http.fetch(`api/collection?name=${this.selectedConnection}`)
             .then((response: any) => { return this.handleErrors(response); })
             .then(result => result.json())
             .then((data: any) =>
@@ -615,7 +635,7 @@ export class Network
 
     private addCollection()
     {
-        this.http.fetch(`api/collection?name=${this.collectionTitle}`, { method: 'post' })
+        this.http.fetch(`api/collection?name=${this.collectionTitle}&connectionName=${this.selectedConnection}`, { method: 'post' })
             .then((response: any) => { return this.handleErrors(response);  })
             .then((response: any) => { this.getCollections(); })
         this.modal = this.modalTypes.None;

--- a/Web/GraphExplorer/Configuration/AppSettings.cs
+++ b/Web/GraphExplorer/Configuration/AppSettings.cs
@@ -4,6 +4,7 @@
 	using Newtonsoft.Json.Linq;
 	using System;
 	using System.IO;
+    using System.Linq;
 
 	// Super simple AppSettings class
 	public sealed class AppSettings
@@ -54,7 +55,13 @@
 		/// <returns></returns>
 		public T GetSection<T>(string sectionName)
 		{
-			return (_allSettings[sectionName] as JObject).ToObject<T>();
+            if (typeof(T).GetInterfaces().Select(a=>a.Name).Contains("IEnumerable"))
+            {
+                var things = _allSettings[sectionName] as JArray;
+                return things.ToObject<T>();
+            }
+            
+            return (_allSettings[sectionName] as JObject).ToObject<T>();
 		}
     }
 }

--- a/Web/GraphExplorer/Configuration/DocDbSetup.cs
+++ b/Web/GraphExplorer/Configuration/DocDbSetup.cs
@@ -1,17 +1,18 @@
 ﻿using Microsoft.Azure.Documents.Client;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphExplorer.Configuration
 {
     public static class DocDbSettings
     {
-        private static DocDbConfig dbConfig = AppSettings.Instance.GetSection<DocDbConfig>("DocumentDBConfig");
-        public static string DatabaseId = dbConfig.Database;
-        public static DocumentClient Client;
+        private static DocDbConfig[] dbConfig = AppSettings.Instance.GetSection<DocDbConfig[]>("DocumentDBConfig");
+        public static Dictionary<string, DocumentClient> Config;
 
         public static void Init()
         {
-            Client = new DocumentClient(new Uri(dbConfig.Endpoint), dbConfig.AuthKey, new ConnectionPolicy { EnableEndpointDiscovery = false });
+            Config = dbConfig.ToDictionary(k => k.Database, v => new DocumentClient(new Uri(v.Endpoint), v.AuthKey, new ConnectionPolicy { EnableEndpointDiscovery = false }));
         }
     }
 }

--- a/Web/GraphExplorer/appsettings.json
+++ b/Web/GraphExplorer/appsettings.json
@@ -1,10 +1,11 @@
 {
-  "DocumentDBConfig":
-  {
-    "endpoint": "DOCUMENTDBURL",
-    "authKey": "DOCUMENTDBSECRET",
-    "database": "DOCUMENTDBDATABASEID"
-  },
+  "DocumentDBConfig": [
+    {
+      "endpoint": "DOCUMENTDBURL",
+      "authKey": "DOCUMENTDBSECRET",
+      "database": "DOCUMENTDBDATABASEID"
+    }
+  ],
   "Logging": 
   {
     "IncludeScopes": false,


### PR DESCRIPTION
Support for multiple graph connection in the same GraphExplorer instance. 
Users can easily define and select a different account.
Updates the GraphUploaderSample functionality that autopopulates the appsettings.json file.